### PR TITLE
No default constructors for extending classes

### DIFF
--- a/src/ConverterContext.hx
+++ b/src/ConverterContext.hx
@@ -499,7 +499,7 @@ class ConverterContext {
 
 				if (classDeclaration != null) {
 					// add default constructor
-					if (!fields.exists(f -> f.name == 'new')) {
+					if (!fields.exists(f -> f.name == 'new') && classSuperType == null) {
 						fields.unshift((macro class { function new(); }).fields[0]);
 					}
 				}


### PR DESCRIPTION
If a class doesn't have an explicit constructor, allow it to automatically get the one from its superclass.